### PR TITLE
Remove deprecated calls to express send()

### DIFF
--- a/lib/duplicate-check.js
+++ b/lib/duplicate-check.js
@@ -66,7 +66,7 @@ DuplicateCheck.prototype.middleware = function( options ){
             }
             catch( err ){
                 options.errorLogFunc( err );
-                return res.send( 500, { errors: [ options.errMsg ] } );
+                return res.status( 500 ).send( { errors: [ options.errMsg ] } );
             }
             _this.raiseFlag( allowOneKey, function( err ){
                 if( !!err ){
@@ -79,7 +79,7 @@ DuplicateCheck.prototype.middleware = function( options ){
                     else if( isDuplicate ){
                         _this.redisClient.del( allowOneKey );
                         options.infoLogFunc( req );
-                        return res.send( 409, { errors: [ options.dupMsg ] } );
+                        return res.status( 409 ).send( { errors: [ options.dupMsg ] } );
                     }
                     else{
                         _this.setHash( redisKey, hash, options.ttl, next );


### PR DESCRIPTION
send( status, body ) has been replaced by
status( status ).send( body )